### PR TITLE
Populate task stats in the DateStats component

### DIFF
--- a/components/Header/DateStats.js
+++ b/components/Header/DateStats.js
@@ -1,14 +1,25 @@
 import format from 'date-fns/format'
 
+import { useAppState } from 'context/AppContext'
+import parseISO from 'date-fns/parseISO'
+import isSameDay from 'date-fns/isSameDay'
+
 export default function DateStats() {
-  const currentDate = format(new Date(), 'EEE, LLL dd, yyyy')
+  const { tasks: { incomplete } } = useAppState()
+  const currentDate = new Date()
+  const tasksTodayCount = incomplete.reduce((count, task) => {
+    const taskDate = parseISO(task.date)
+    const areDatesEqual = isSameDay(currentDate, taskDate)
+    return areDatesEqual ? count + 1 : count
+  }, 0)
+  const tasksOverdueCount = incomplete.length - tasksTodayCount
 
   return (
     <div>
-      <p className="text-white mb-0 fw-bolder">{currentDate}</p>
-      <span className="text-info mb-0 fs-6">3 Active Tasks</span>
+      <p className="text-white mb-0 fw-bolder">{format(currentDate, 'EEE, LLL dd, yyyy')}</p>
+      <span className="text-info mb-0 fs-6">{`${tasksTodayCount} Tasks Today`}</span>
       <span className="text-white mb-0 fs-6"> / </span>
-      <span className="text-danger mb-0 fs-6">3 Incomplete Tasks</span>
+      <span className="text-danger mb-0 fs-6">{`${tasksOverdueCount} Tasks Overdue`}</span>
     </div>
   )
 }


### PR DESCRIPTION
### 🤔 Why?
The `DateStats` component currently only displays dummy data. We want it to display the actual tasks numbers.