### PR TITLE
Redirect root page to /incomplete

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -5,7 +5,7 @@ import DateStats from './DateStats';
 
 const pagePaths: { href: string; label: string }[] = [
   {
-    href: '/',
+    href: '/incomplete',
     label: 'Incomplete Tasks',
   },
   {

--- a/src/pages/incomplete/index.tsx
+++ b/src/pages/incomplete/index.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+import Head from 'next/head';
+
+import Tasks from 'src/components/Tasks';
+import { useAppState } from 'src/context/AppContext';
+import { useLoadTasks } from 'src/hooks/useApi';
+
+const title = 'Incomplete Tasks';
+
+export default function Incomplete() {
+  const {
+    tasks: { incomplete },
+  } = useAppState();
+  const { execute } = useLoadTasks();
+
+  useEffect(() => {
+    execute();
+  }, []);
+
+  return (
+    <div>
+      <Head>
+        <title>{title}</title>
+      </Head>
+      <Tasks tasks={incomplete} />
+    </div>
+  );
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      requiresAuth: true,
+    },
+  };
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,36 +1,11 @@
-import React, { useEffect } from 'react';
-import Head from 'next/head';
-
-import Tasks from 'src/components/Tasks';
-import { useAppState } from 'src/context/AppContext';
-import { useLoadTasks } from 'src/hooks/useApi';
-
-const title = 'Incomplete Tasks';
-
 export default function Home() {
-  const {
-    tasks: { incomplete },
-  } = useAppState();
-  const { execute } = useLoadTasks();
-
-  useEffect(() => {
-    execute();
-  }, []);
-
-  return (
-    <div>
-      <Head>
-        <title>{title}</title>
-      </Head>
-      <Tasks tasks={incomplete} />
-    </div>
-  );
+  return <div />;
 }
 
 export async function getStaticProps() {
   return {
-    props: {
-      requiresAuth: true,
+    redirect: {
+      destination: '/incomplete',
     },
   };
 }


### PR DESCRIPTION
### 🤔 Why?
I'm not a fan that incomplete tasks are shown in the `/` page. I'd like it more if we have parallelism in our pages e.g. `/incomplete` and `/complete`