### PR TITLE
Show loader on initial page load

### DIFF
--- a/src/pages/complete/index.tsx
+++ b/src/pages/complete/index.tsx
@@ -4,18 +4,22 @@ import Head from 'next/head';
 import { useAppState } from 'src/context/AppContext';
 import { useLoadTasks } from 'src/hooks/useTaskApi';
 import Tasks from 'src/components/Tasks';
+import SkeletonLoader from 'src/components/SkeletonLoader';
 
 const title = 'Completed Tasks';
 
 export default function CompletedTodos() {
-  const {
-    tasks: { complete },
-  } = useAppState();
-  const { execute } = useLoadTasks();
+  const { execute, isLoading } = useLoadTasks();
+  const { tasks } = useAppState();
+  const { complete } = tasks;
 
   useEffect(() => {
     execute();
   }, []);
+
+  if (isLoading) {
+    return <SkeletonLoader />;
+  }
 
   return (
     <div>


### PR DESCRIPTION
### 🤔 Why?
We want the same behavior of the incomplete page in the complete page. On the initial page load, we want to show users that we are fetching tasks.