### PR TITLE
Lift loading tasks state and apply to whole app 🆙

### DIFF
--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -1,9 +1,9 @@
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-import { Placeholder } from 'react-bootstrap';
 
 import { useAuthState } from 'src/context/AuthContext';
 import { useSilentLogin } from 'src/hooks/useAuthApi';
+import SkeletonLoader from '../SkeletonLoader';
 
 type AuthProps = {
   children: JSX.Element;
@@ -25,16 +25,7 @@ export default function Auth({ children }: AuthProps) {
   }, [isLoading, user]);
 
   if (isLoading || !user) {
-    return (
-      <>
-        <Placeholder as="p" animation="glow">
-          <Placeholder xs={12} bg="light" />
-        </Placeholder>
-        <Placeholder as="p" animation="glow">
-          <Placeholder xs={12} bg="light" />
-        </Placeholder>
-      </>
-    );
+    return <SkeletonLoader levels={3} />;
   }
 
   return children;

--- a/src/components/Header/DateStats.tsx
+++ b/src/components/Header/DateStats.tsx
@@ -3,11 +3,11 @@ import format from 'date-fns/format';
 import { useAppState } from 'src/context/AppContext';
 import parseISO from 'date-fns/parseISO';
 import isSameDay from 'date-fns/isSameDay';
+import { Placeholder } from 'react-bootstrap';
 
 export default function DateStats() {
-  const {
-    tasks: { incomplete },
-  } = useAppState();
+  const { tasks, isLoadingTasks } = useAppState();
+  const { incomplete } = tasks;
   const currentDate = new Date();
   const tasksTodayCount = incomplete.reduce((count: number, task: Task) => {
     const taskDate = parseISO(task.createdAt);
@@ -16,14 +16,24 @@ export default function DateStats() {
   }, 0);
   const tasksOverdueCount = incomplete.length - tasksTodayCount;
 
+  const stats = isLoadingTasks ? (
+    <Placeholder as="p" animation="glow" classNa>
+      <Placeholder xs={12} bg="light" />
+    </Placeholder>
+  ) : (
+    <>
+      <span className="text-info mb-0 fs-6">{`${tasksTodayCount} Tasks Today`}</span>
+      <span className="text-white mb-0 fs-6"> / </span>
+      <span className="text-danger mb-0 fs-6">{`${tasksOverdueCount} Tasks Overdue`}</span>
+    </>
+  );
+
   return (
     <div>
       <p className="text-white mb-0 fw-bolder">
         {format(currentDate, 'EEE, LLL dd, yyyy')}
       </p>
-      <span className="text-info mb-0 fs-6">{`${tasksTodayCount} Tasks Today`}</span>
-      <span className="text-white mb-0 fs-6"> / </span>
-      <span className="text-danger mb-0 fs-6">{`${tasksOverdueCount} Tasks Overdue`}</span>
+      {stats}
     </div>
   );
 }

--- a/src/components/SkeletonLoader/index.tsx
+++ b/src/components/SkeletonLoader/index.tsx
@@ -1,14 +1,23 @@
 import { Placeholder } from 'react-bootstrap';
 
-export default function SkeletonLoader() {
-  return (
+type SkeletonLoaderProps = {
+  levels?: number;
+};
+
+export default function SkeletonLoader(props: SkeletonLoaderProps) {
+  const { levels = 1 } = props;
+
+  const loader = (
     <>
-      <Placeholder as="p" animation="glow">
-        <Placeholder xs={12} bg="light" />
-      </Placeholder>
-      <Placeholder as="p" animation="glow">
-        <Placeholder xs={12} bg="light" />
-      </Placeholder>
+      {Array(levels)
+        .fill(1)
+        .map(() => (
+          <Placeholder as="p" animation="glow">
+            <Placeholder xs={12} bg="light" />
+          </Placeholder>
+        ))}
     </>
   );
+
+  return loader;
 }

--- a/src/context/AppContext/dispatchActions.ts
+++ b/src/context/AppContext/dispatchActions.ts
@@ -1,0 +1,44 @@
+export enum ACTION_TYPES {
+  ADD_TASK = 'ADD_TASK',
+  DELETE_TASK = 'DELETE_TASK',
+  START_LOAD_TASKS = 'START_LOAD_TASKS',
+  LOAD_TASKS = 'LOAD_TASKS',
+  FINISH_LOAD_TASKS = 'FINISH_LOAD_TASKS',
+  UPDATE_TASK = 'UPDATE_TASK',
+}
+
+type AddTaskAction = {
+  type: ACTION_TYPES.ADD_TASK;
+  payload: Task;
+};
+
+type DeleteTaskAction = {
+  type: ACTION_TYPES.DELETE_TASK;
+  payload: number;
+};
+
+type StartLoadTaskAction = {
+  type: ACTION_TYPES.START_LOAD_TASKS;
+};
+
+type LoadTaskAction = {
+  type: ACTION_TYPES.LOAD_TASKS;
+  payload: Task[];
+};
+
+type FinishLoadTaskAction = {
+  type: ACTION_TYPES.FINISH_LOAD_TASKS;
+};
+
+type UpdateTaskAction = {
+  type: ACTION_TYPES.UPDATE_TASK;
+  payload: { id: number; task: Task };
+};
+
+export type ACTIONS =
+  | AddTaskAction
+  | DeleteTaskAction
+  | LoadTaskAction
+  | StartLoadTaskAction
+  | FinishLoadTaskAction
+  | UpdateTaskAction;

--- a/src/hooks/useTaskApi.ts
+++ b/src/hooks/useTaskApi.ts
@@ -85,14 +85,13 @@ export function useLoadTasks() {
   };
 
   const { axiosPrivate } = useAxiosPrivate();
-  const { loadTasks } = useAppDispatch();
-  const [isLoading, setIsLoading] = useState(false);
+  const { loadTasks, startLoadingTasks, finishLoadingTasks } = useAppDispatch();
   const [data, setData] = useState<GetTasksResponse | null>(null);
   const [error, setError] = useState<unknown>(null);
 
   const execute = async (queryParams: QueryParams = {}) => {
     try {
-      setIsLoading(true);
+      startLoadingTasks();
 
       const response = await axiosPrivate.get<GetTasksResponse>('/task', {
         params: queryParams,
@@ -100,14 +99,14 @@ export function useLoadTasks() {
 
       setData(response.data);
       loadTasks(response.data.data);
-      setIsLoading(false);
+      finishLoadingTasks();
     } catch (err: unknown) {
       setError(err);
-      setIsLoading(false);
+      finishLoadingTasks();
     }
   };
 
-  return { data, error, execute: useCallback(execute, []), isLoading };
+  return { data, error, execute: useCallback(execute, []) };
 }
 
 export function useDeleteTask() {

--- a/src/pages/complete/index.tsx
+++ b/src/pages/complete/index.tsx
@@ -9,16 +9,16 @@ import SkeletonLoader from 'src/components/SkeletonLoader';
 const title = 'Completed Tasks';
 
 export default function CompletedTodos() {
-  const { execute, isLoading } = useLoadTasks();
-  const { tasks } = useAppState();
+  const { execute } = useLoadTasks();
+  const { tasks, isLoadingTasks } = useAppState();
   const { complete } = tasks;
 
   useEffect(() => {
     execute();
   }, []);
 
-  if (isLoading) {
-    return <SkeletonLoader />;
+  if (isLoadingTasks) {
+    return <SkeletonLoader levels={4} />;
   }
 
   return (

--- a/src/pages/incomplete/index.tsx
+++ b/src/pages/incomplete/index.tsx
@@ -9,16 +9,16 @@ import SkeletonLoader from 'src/components/SkeletonLoader';
 const title = 'Incomplete Tasks';
 
 export default function Incomplete() {
-  const { execute, isLoading } = useLoadTasks();
-  const { tasks } = useAppState();
+  const { execute } = useLoadTasks();
+  const { tasks, isLoadingTasks } = useAppState();
   const { incomplete } = tasks;
 
   useEffect(() => {
     execute();
   }, []);
 
-  if (isLoading) {
-    return <SkeletonLoader />;
+  if (isLoadingTasks) {
+    return <SkeletonLoader levels={4} />;
   }
 
   return (


### PR DESCRIPTION
### 🤔 Why?
I noticed when loading tasks, we also need to display a loader in place of the `DateStats` component since it shows the total incomplete tasks a user has. For that reason, I decided to life the loading state of the `GET /task` request so it can be shared in different parts of the app.