### PR TITLE
Remove tasks if a 404 error is encountered

### DIFF
--- a/src/components/SkeletonLoader/index.tsx
+++ b/src/components/SkeletonLoader/index.tsx
@@ -12,7 +12,7 @@ export default function SkeletonLoader(props: SkeletonLoaderProps) {
       {Array(levels)
         .fill(1)
         .map(() => (
-          <Placeholder as="p" animation="glow">
+          <Placeholder as="p" animation="glow" key={Date.now() * Math.random()}>
             <Placeholder xs={12} bg="light" />
           </Placeholder>
         ))}

--- a/src/helpers/error.ts
+++ b/src/helpers/error.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type ErrorResponseWithMessage = {
+  response: {
+    data: {
+      message: string;
+    };
+  };
+};
+
+export function isErrorWithMessage(
+  error: any
+): error is ErrorResponseWithMessage {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error &&
+    'data' in error.response &&
+    'message' in error.response.data &&
+    typeof (error as Record<string, any>).response.data.message === 'string'
+  );
+}

--- a/src/hooks/useTaskApi.ts
+++ b/src/hooks/useTaskApi.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { useCallback, useState } from 'react';
 
+import { isErrorWithMessage } from 'src/helpers/error';
 import { useAppDispatch } from 'src/context/AppContext';
 import useAxiosPrivate from './useAxiosPrivate';
 
@@ -46,7 +47,7 @@ export function useUpdateTask() {
   };
 
   const { axiosPrivate } = useAxiosPrivate();
-  const { updateTask } = useAppDispatch();
+  const { updateTask, deleteTask } = useAppDispatch();
   const [isLoading, setIsLoading] = useState(false);
   const [data, setData] = useState<UpdateTaskResponse | null>(null);
   const [error, setError] = useState<unknown>(null);
@@ -64,6 +65,14 @@ export function useUpdateTask() {
       setData(response.data);
       setIsLoading(false);
     } catch (err: unknown) {
+      if (
+        isErrorWithMessage(err) &&
+        err.response.data.message === 'No task found'
+      ) {
+        // This catches instances where a user is trying to delete a task that no longer exists e.g. has been deleted from another session.
+        deleteTask(id);
+      }
+
       setError(err);
       setIsLoading(false);
     }
@@ -133,6 +142,14 @@ export function useDeleteTask() {
       setData(response.data);
       setIsLoading(false);
     } catch (err: unknown) {
+      if (
+        isErrorWithMessage(err) &&
+        err.response.data.message === 'No task found'
+      ) {
+        // This catches instances where a user is trying to delete a task that no longer exists e.g. has been deleted from another session.
+        deleteTask(taskId);
+      }
+
       setError(err);
       setIsLoading(false);
     }


### PR DESCRIPTION
### 🤔 Why?
If a task is deleted from another browser session, it will stay in a different browser session of the same user unless the page gets refreshed. Actions applied to that deleted task will cause 404 errors in the server so we want to handle those by making sure that when we do encounter a 404, we should just remove that task from the store.