### PR TITLE
Improve redirect logic after authentication 🤓

### DIFF
--- a/src/hooks/useAuthApi.ts
+++ b/src/hooks/useAuthApi.ts
@@ -30,11 +30,12 @@ export function useRegisterUser({ redirectTo }: AuthHookOptions = {}) {
       setData(response.data);
       setUser(response.data.user);
       session.setAuthToken(response.data.token);
-      setIsLoading(false);
 
       if (redirectTo) {
-        router.push(redirectTo);
+        await router.push(redirectTo);
       }
+
+      setIsLoading(false);
     } catch (err: unknown) {
       setError(err);
     }
@@ -63,13 +64,15 @@ export function useLogin({ redirectTo }: AuthHookOptions = {}) {
       setData(response.data);
       setUser(response.data.user);
       session.setAuthToken(response.data.token);
-      setIsLoading(false);
 
       if (redirectTo) {
-        router.push(redirectTo);
+        await router.push(redirectTo);
       }
+
+      setIsLoading(false);
     } catch (err: unknown) {
       setError(err);
+      setIsLoading(false);
     }
   };
 


### PR DESCRIPTION
### 🤔 Why?
I noticed that when a user logs in or registers, the form resets before being redirected to the authenticated pages. I don't think it's a good user experience so what I did was to make sure that the redirect happens first before the forms get reset.