### PR TITLE
Fix redirect from login and register pages after authentication 🗺

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/incomplete',
+        permanent: true,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,3 @@
 export default function Home() {
   return <div />;
 }
-
-export async function getStaticProps() {
-  return {
-    redirect: {
-      destination: '/incomplete',
-    },
-  };
-}

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -15,7 +15,7 @@ export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showForm, setShowForm] = useState(false);
-  const { execute, isLoading } = useLogin({ redirectTo: '/' });
+  const { execute, isLoading } = useLogin({ redirectTo: '/incomplete' });
   const session = useSession();
   const router = useRouter();
 
@@ -27,6 +27,10 @@ export default function Login() {
     } else {
       setShowForm(true);
     }
+  }, []);
+
+  useEffect(() => {
+    router.prefetch('/incomplete');
   }, []);
 
   const formSubmitHandler = async (e: React.FormEvent) => {

--- a/src/pages/register/index.tsx
+++ b/src/pages/register/index.tsx
@@ -8,12 +8,12 @@ import SpinnerButton from 'src/components/SpinnerButton';
 
 const title = 'Register User';
 
-export default function Register(): JSX.Element {
+export default function Register() {
   const [name, setName] = useState('');
   const [age, setAge] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const { execute, isLoading } = useRegisterUser({ redirectTo: '/' });
+  const { execute, isLoading } = useRegisterUser({ redirectTo: '/incomplete' });
 
   const formSubmitHandler = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
### 🤔 Why?
So, I tried deploying the app and it gave me a nasty error saying
```
Error: `redirect` can not be returned from getStaticProps during prerendering
```
Apparently, the way I implemented redirects using `getStaticProps` in the root page is frowned upon 🤷‍♂️